### PR TITLE
feat(container): add Dockerfile, to be able to use it in ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+ENV PATH=/root/.local/bin:$PATH
+ENV GITLAB_LINT_DOMAIN=""
+ENV GITLAB_LINT_PROJECT=""
+ENV GITLAB_LINT_TOKEN=""
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --user --no-cache-dir -r /requirements.txt && \
+    pip3 install --user --no-cache-dir gitlab_lint
+ENTRYPOINT [ "gll" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Hi,

we generate in our ci some .gitlab-ci.yml files and want to check, if they are working or not.
For now, we install gll and deps for every run. We want to speed up our builds.

Could we also push this to dockerhub or ghcr?

BR
Kai